### PR TITLE
v0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches:
+      - '!main'
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
This pull request improves the documentation and end-to-end (E2E) test coverage for the IXDTF Go library, clarifying strict vs. non-strict mode behavior and adding comprehensive round-trip and timezone validation scenarios. It also updates the CI workflow configuration.

**Documentation improvements:**

* Expanded the `README.md` with clearer examples for parsing, formatting, and validating IXDTF strings, including strict vs. non-strict mode behavior, error reporting, and round-trip guarantees. Examples now demonstrate timezone/offset mismatches and critical tag handling. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-L18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R89) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R102) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R118)

**Test enhancements:**

* Overhauled the E2E test (`test/e2e_test.go`) to:
  - Add cases for strict/non-strict validation, critical tag errors, and round-tripping through different timezones.
  - Validate that formatting/parsing with mismatched offsets and timezones behaves as expected in both modes.
  - Check that formatting with a new timezone extension and re-validation works correctly, including offset mismatch errors in strict mode. [[1]](diffhunk://#diff-9e762d0df1502ee31a1de1a3bc67be6c2707ec3e6117be3147907a60ef5fb854R5-R72) [[2]](diffhunk://#diff-9e762d0df1502ee31a1de1a3bc67be6c2707ec3e6117be3147907a60ef5fb854R88-R137)

**CI workflow update:**

* Modified the GitHub Actions CI workflow to prevent running on pushes to the `main` branch, likely to avoid redundant builds or enforce PR-based development.