### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-01-18
+
+### Changed
+
+- In strict mode, `u-ca` calendar tags are now validated even when non-critical, returning a clear error for unknown identifiers
+
+### Fixed
+
+- Ensured `Parse` and `Validate` both apply strict calendar tag validation consistently
+
+### Technical
+
+- Added tests covering non-critical invalid calendar tags in strict mode
+
 ## [0.3.0] - 2026-01-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,11 +152,14 @@ The following extension patterns are automatically rejected:
 
 #### Unicode Calendar Identifier Validation
 
-The `u-ca` extension is validated against known Unicode calendar identifiers:
+The `u-ca` extension is validated against known Unicode calendar identifiers.
+Invalid values always error when the tag is critical (`!u-ca`), and also error in
+strict mode even when non-critical:
 
 ```go
 "2023-08-07T14:30:00Z[!u-ca=gregorian]" // OK
 "2023-08-07T14:30:00Z[!u-ca=unknown]"   // Error: invalid calendar tag identifier
+"2023-08-07T14:30:00Z[u-ca=unknown]"    // Error in strict mode
 ```
 
 ## API Reference
@@ -185,7 +188,8 @@ Notes:
 - An invalid or unresolvable time zone name always yields an error (regardless of mode).
 - Time zones with `Etc/GMT±X` naming are skipped for consistency checking (POSIX inverted offset semantics would cause false positives).
 - `Validate` follows the same policy: with `strict=false` an offset mismatch is considered acceptable.
-- Extension tag syntax and critical tag handling are independent of `strict`.
+- Extension tag syntax and critical tag handling are independent of `strict`, except for
+  `u-ca` validation which is enforced in strict mode even for non-critical tags.
 - Recommended usage: accept loosely formed inputs with `strict=false` at system boundaries (ingest phase), then re-normalize if needed; enforce `strict=true` where data integrity or audit requirements apply.
 
 ### Types

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -336,6 +336,12 @@ func TestParse(t *testing.T) {
 			}),
 		},
 		{
+			name:    "with invalid calendar tag (non-critical, strict)",
+			input:   "2025-03-04T05:06:07Z[u-ca=hoge]",
+			strict:  true,
+			wantErr: "invalid calendar tag identifier",
+		},
+		{
 			name:    "with invalid calendar tag (critical)",
 			input:   "2025-03-04T05:06:07Z[!u-ca=hoge]",
 			strict:  false,
@@ -642,6 +648,12 @@ func TestValidate(t *testing.T) {
 			name:   "valid with invalid calendar tag (non-critical)",
 			input:  "2025-03-04T05:06:07Z[u-ca=hoge]",
 			strict: false,
+		},
+		{
+			name:    "invalid calendar tag (non-critical, strict)",
+			input:   "2025-03-04T05:06:07Z[u-ca=hoge]",
+			strict:  true,
+			wantErr: "IXDTFE parsing time \"2025-03-04T05:06:07Z[u-ca=hoge]\" as \"2006-01-02T15:04:05Z07:00*([time-zone-name][tags])\": invalid calendar tag identifier",
 		},
 		{
 			name:    "invalid calendar tag (critical)",


### PR DESCRIPTION
## [0.3.1] - 2026-01-18

### Changed

- In strict mode, `u-ca` calendar tags are now validated even when non-critical, returning a clear error for unknown identifiers

### Fixed

- Ensured `Parse` and `Validate` both apply strict calendar tag validation consistently

### Technical

- Added tests covering non-critical invalid calendar tags in strict mode