### PR TITLE
fix: treat Z/-00:00 as unknown local offset per RFC 9557 (#22)

### DIFF
--- a/ixdtf.go
+++ b/ixdtf.go
@@ -172,7 +172,8 @@ func Parse(s string, strict bool) (time.Time, *IXDTFExtensions, error) {
 
 	// Check timezone consistency if timezone is provided
 	if ext.Location != nil {
-		result, checkErr := checkTimezoneConsistency(t, ext.Location, strict)
+		offsetUnknown := hasUnknownLocalOffset(rfc3339Portion)
+		result, checkErr := checkTimezoneConsistency(t, ext.Location, strict, offsetUnknown)
 		if checkErr != nil {
 			return time.Time{}, nil, newParseError(
 				LayoutRFC3339NanoExtended,
@@ -221,7 +222,8 @@ func Validate(s string, strict bool) error {
 
 	// Check timezone consistency if timezone is provided
 	if ext != nil && ext.Location != nil {
-		_, tzErr := checkTimezoneConsistency(t, ext.Location, strict)
+		offsetUnknown := hasUnknownLocalOffset(rfc3339Portion)
+		_, tzErr := checkTimezoneConsistency(t, ext.Location, strict, offsetUnknown)
 		if tzErr != nil {
 			return newParseError(LayoutRFC3339NanoExtended, s, tzErr)
 		}
@@ -301,6 +303,7 @@ func checkTimezoneConsistency(
 	timestamp time.Time,
 	location *time.Location,
 	strict bool,
+	offsetUnknown bool,
 ) (*TimezoneConsistencyResult, error) {
 	result := &TimezoneConsistencyResult{
 		Location: location,
@@ -324,6 +327,20 @@ func checkTimezoneConsistency(
 		loc = loaded
 	}
 	result.Location = loc
+
+	// Per RFC 3339 Section 4.3 (as updated by RFC 9557 Section 2.2) and
+	// RFC 9557 Section 3.4 (Figure 2): when the RFC 3339 part carries an
+	// unknown local offset ("Z" or "-00:00"), the instant in UTC is known but
+	// no specific local offset is asserted. Pairing it with a time-zone
+	// annotation is therefore never an inconsistency; resolve local time using
+	// the annotation's rules rather than comparing offsets.
+	// See https://www.rfc-editor.org/rfc/rfc9557#section-3.4 (Figure 2).
+	if offsetUnknown {
+		_, result.OriginalOffset = timestamp.Zone()
+		_, result.ExpectedOffset = timestamp.In(loc).Zone()
+		result.IsConsistent = true
+		return result, nil
+	}
 
 	// Get the timezone offset for the given timestamp.
 	expectedTimestamp := timestamp.In(loc)
@@ -361,6 +378,29 @@ func findRFC3339End(s string) int {
 		}
 	}
 	return len(s)
+}
+
+// hasUnknownLocalOffset reports whether the RFC 3339 portion uses the
+// "unknown local offset" designator defined in RFC 3339 Section 4.3 and
+// updated by RFC 9557 Section 2.2: a "Z" or a negative-zero offset "-00:00".
+//
+// In that case the instant in UTC is known but no specific local offset is
+// asserted, so pairing it with a time-zone annotation is never an
+// inconsistency (RFC 9557 Section 3.4, Figure 2); the annotation's rules are
+// applied to resolve local time. This differs from a concrete "+00:00", which
+// asserts a zero offset and can therefore conflict with the annotation.
+//
+// References:
+//   - RFC 3339 Section 4.3: https://www.rfc-editor.org/rfc/rfc3339#section-4.3
+//   - RFC 9557 Section 2.2: https://www.rfc-editor.org/rfc/rfc9557#section-2.2
+//   - RFC 9557 Section 3.4: https://www.rfc-editor.org/rfc/rfc9557#section-3.4
+func hasUnknownLocalOffset(rfc3339Portion string) bool {
+	if n := len(rfc3339Portion); n > 0 {
+		if c := rfc3339Portion[n-1]; c == 'Z' || c == 'z' {
+			return true
+		}
+	}
+	return strings.HasSuffix(rfc3339Portion, "-00:00")
 }
 
 func isValidSuffixKeyRange(s string, start, end int) error {

--- a/ixdtf_internal_test.go
+++ b/ixdtf_internal_test.go
@@ -35,7 +35,7 @@ func TestCheckTimezoneConsistency(t *testing.T) {
 		t.Parallel()
 		timezoneCache.Delete("Asia/Tokyo")
 		placeholder := time.FixedZone("Asia/Tokyo", 9*3600)
-		res, err := checkTimezoneConsistency(now, placeholder, false)
+		res, err := checkTimezoneConsistency(now, placeholder, false, false)
 		if err != nil {
 			t.Fatalf("expected fallback load to succeed, got %v", err)
 		}
@@ -46,15 +46,33 @@ func TestCheckTimezoneConsistency(t *testing.T) {
 
 	t.Run("nil location", func(t *testing.T) {
 		t.Parallel()
-		if res, err := checkTimezoneConsistency(now, nil, false); err != nil || !res.IsConsistent {
+		if res, err := checkTimezoneConsistency(now, nil, false, false); err != nil || !res.IsConsistent {
 			t.Fatalf("expected nil location to be consistent, got res=%+v err=%v", res, err)
 		}
 	})
 
 	t.Run("strict mode with unknown fixed zone", func(t *testing.T) {
 		t.Parallel()
-		if _, err := checkTimezoneConsistency(now, time.FixedZone("+0900", 9*3600), true); err == nil {
+		if _, err := checkTimezoneConsistency(now, time.FixedZone("+0900", 9*3600), true, false); err == nil {
 			t.Fatalf("expected strict mode to fail for unknown fixed zone")
+		}
+	})
+
+	t.Run("unknown local offset is consistent even in strict mode", func(t *testing.T) {
+		t.Parallel()
+		london, err := time.LoadLocation("Europe/London")
+		if err != nil {
+			t.Skipf("Europe/London unavailable: %v", err)
+		}
+		// July: London is BST (+01:00), which differs from the Z offset (0),
+		// yet an unknown local offset must never be flagged as inconsistent.
+		summer := time.Date(2022, 7, 8, 0, 14, 7, 0, time.UTC)
+		res, err := checkTimezoneConsistency(summer, london, true, true)
+		if err != nil {
+			t.Fatalf("unknown offset should not error in strict mode, got %v", err)
+		}
+		if !res.IsConsistent {
+			t.Fatalf("unknown offset should be consistent, got %+v", res)
 		}
 	})
 }

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -301,6 +301,17 @@ func TestParse(t *testing.T) {
 			wantExt:  ixdtf.NewIXDTFExtensions(nil),
 		},
 		{
+			// RFC 9557 Section 3.4 (Figure 2): Z is an unknown local offset, so
+			// pairing it with a timezone is consistent even in strict mode.
+			name:     "Z with IANA timezone is consistent in strict mode",
+			input:    "2022-07-08T00:14:07Z[Europe/London]",
+			strict:   true,
+			wantTime: time.Date(2022, 7, 8, 0, 14, 7, 0, time.UTC),
+			wantExt: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{
+				Location: time.FixedZone("Europe/London", 0),
+			}),
+		},
+		{
 			name:     "with timezone",
 			input:    "2025-02-03T04:05:06+09:00[Asia/Tokyo]",
 			strict:   false,
@@ -938,4 +949,90 @@ func getTestTimezones() (*time.Location, *time.Location, *time.Location) {
 	return time.FixedZone("Asia/Tokyo", 9*3600),
 		time.FixedZone("Europe/Paris", 1*3600),
 		time.FixedZone("CET", 1*3600)
+}
+
+// TestParseUnknownLocalOffsetAppliesTimezone verifies RFC 9557 Section 3.4
+// (Figure 2): when the RFC 3339 part uses an unknown local offset ("Z" or
+// "-00:00"), the time-zone annotation is applied to resolve local time, and
+// this is never treated as an inconsistency — in either strict or non-strict
+// mode. See https://github.com/8beeeaaat/ixdtf/issues/22.
+func TestParseUnknownLocalOffsetAppliesTimezone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      string
+		wantOffset int // seconds east of UTC after applying the timezone
+		wantHour   int // local wall-clock hour after applying the timezone
+	}{
+		{
+			name:       "Z with London in summer applies BST (+01:00)",
+			input:      "2022-07-08T00:14:07Z[Europe/London]",
+			wantOffset: 1 * 3600,
+			wantHour:   1,
+		},
+		{
+			name:       "Z with London in winter applies GMT (+00:00)",
+			input:      "2022-01-08T00:14:07Z[Europe/London]",
+			wantOffset: 0,
+			wantHour:   0,
+		},
+		{
+			name:       "negative-zero offset with London applies BST",
+			input:      "2022-07-08T00:14:07-00:00[Europe/London]",
+			wantOffset: 1 * 3600,
+			wantHour:   1,
+		},
+		{
+			name:       "Z with New York in summer applies EDT (-04:00)",
+			input:      "2022-07-08T12:00:00Z[America/New_York]",
+			wantOffset: -4 * 3600,
+			wantHour:   8,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, strict := range []bool{false, true} {
+				got, ext, err := ixdtf.Parse(tc.input, strict)
+				if err != nil {
+					t.Fatalf("Parse(%q, %v) unexpected error: %v", tc.input, strict, err)
+				}
+				if _, off := got.Zone(); off != tc.wantOffset {
+					t.Errorf("Parse(%q, %v) offset = %d, want %d", tc.input, strict, off, tc.wantOffset)
+				}
+				if got.Hour() != tc.wantHour {
+					t.Errorf("Parse(%q, %v) local hour = %d, want %d", tc.input, strict, got.Hour(), tc.wantHour)
+				}
+				if ext.Location == nil {
+					t.Errorf("Parse(%q, %v) expected location to be set", tc.input, strict)
+				}
+			}
+		})
+	}
+}
+
+// TestParseNumericZeroOffsetStillInconsistent verifies the contrast with Z: a
+// concrete "+00:00" asserts a zero offset, so it conflicts with a timezone
+// whose offset differs at that instant (RFC 9557 Section 3.4, Figure 1). This
+// behavior must remain unchanged by the Z fix.
+func TestParseNumericZeroOffsetStillInconsistent(t *testing.T) {
+	t.Parallel()
+
+	const input = "2022-07-08T00:14:07+00:00[Europe/London]" // London is BST (+01:00) in July
+
+	// strict mode: the inconsistency is reported as an error.
+	if _, _, err := ixdtf.Parse(input, true); err == nil {
+		t.Fatalf("Parse(%q, true) expected inconsistency error, got nil", input)
+	}
+
+	// non-strict mode: the original +00:00 offset is preserved (timezone not applied).
+	got, _, err := ixdtf.Parse(input, false)
+	if err != nil {
+		t.Fatalf("Parse(%q, false) unexpected error: %v", input, err)
+	}
+	if _, off := got.Zone(); off != 0 {
+		t.Errorf("Parse(%q, false) offset = %d, want 0 (original preserved)", input, off)
+	}
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -16,7 +16,9 @@ func TestE2E_RoundTrip(t *testing.T) {
 			inputHasErrorInStrictMode:                false,
 			overrideWithNyExt:                        "2025-01-02T03:04:05Z[America/New_York]",
 			overrideWithNyExtHasErrorInNonStrictMode: false,
-			overrideWithNyExtHasErrorInStrictMode:    true,
+			// Z denotes an unknown local offset, so pairing it with a time-zone
+			// annotation is not an inconsistency (RFC 9557 Section 3.4, Figure 2).
+			overrideWithNyExtHasErrorInStrictMode: false,
 		},
 		{
 			name:                         "basic UTC time with invalid critical time zone tag",
@@ -74,7 +76,9 @@ func TestE2E_RoundTrip(t *testing.T) {
 			inputHasErrorInStrictMode:                false,
 			overrideWithNyExt:                        "2025-03-04T05:06:07Z[America/New_York][u-ca=gregory]",
 			overrideWithNyExtHasErrorInNonStrictMode: false,
-			overrideWithNyExtHasErrorInStrictMode:    true,
+			// Z denotes an unknown local offset, so pairing it with a time-zone
+			// annotation is not an inconsistency (RFC 9557 Section 3.4, Figure 2).
+			overrideWithNyExtHasErrorInStrictMode: false,
 		},
 		{
 			name:                                     "with critical tags",


### PR DESCRIPTION
## Summary

Fixes #22 — IXDTF misinterpreted `Z` as a concrete `+00:00` offset when checking timezone consistency.

Per **RFC 3339 §4.3** (updated by **RFC 9557 §2.2**), `Z` and `-00:00` denote an **unknown local offset**: the instant in UTC is known, but no specific local offset is asserted. **RFC 9557 §3.4 (Figure 2)** shows that pairing such an offset with a time-zone annotation is **not** an inconsistency — the annotation's rules should be applied to resolve local time.

### Before

`2022-07-08T00:14:07Z[Europe/London]`:
- **strict** → spurious `timezone offset does not match` error
- **non-strict** → kept UTC wall clock, timezone not applied

### After

`Z`/`-00:00` + timezone → the zone is applied (instant preserved), consistent in **both** modes:
- `2022-07-08T00:14:07Z[Europe/London]` → `2022-07-08T01:14:07+01:00` (BST)

A concrete `+00:00[Europe/London]` still asserts a zero offset and remains **inconsistent** (RFC 9557 Figure 1) — unchanged.

## Implementation

- New `hasUnknownLocalOffset()` detects the `Z`/`-00:00` designator from the raw RFC 3339 portion (Go's `time.Parse` collapses `Z` and `+00:00`, so raw-string inspection is required).
- `checkTimezoneConsistency()` gains an `offsetUnknown` argument; when set, it skips the offset comparison and reports consistent so the annotation is applied.
- `Parse()` / `Validate()` pass the flag through.
- Comments cite the relevant RFC sections (with URLs) as evidence.

## Tests

- `TestParse`: strict-mode consistency case for the issue example.
- `TestParseUnknownLocalOffsetAppliesTimezone`: offset/wall-clock assertions for `Z` and `-00:00` across DST (London summer/winter, New York summer).
- `TestParseNumericZeroOffsetStillInconsistent`: contrast test proving `+00:00` stays inconsistent.
- `TestCheckTimezoneConsistency`: internal `offsetUnknown` case.
- `test/e2e_test.go`: updated two expectations that encoded the old, non-compliant behavior.

## Quality gate

- `go test ./...` / `go test -race ./...` ✅
- `go vet ./...` / `gofmt` ✅
- `golangci-lint run` → 0 issues ✅
- `go mod tidy` → no dependency changes ✅ (zero external deps)

## Out of scope (follow-up)

The critical-flag form `[!Europe/London]` (shown alongside the example in RFC 9557 Figure 2) is currently rejected as an invalid timezone. That looks like a separate bug and is left for a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)