### PR TITLE
fix: accept critical "!" flag on time-zone annotations per RFC 9557

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ func main() {
     fmt.Printf("Parsed Time: %v\n", parsedTime)
     // => Parsed Time: 2025-01-02 03:04:05 -0500 EST
     fmt.Printf("Extensions: %+v\n", parsedExt)
-    // => &ixdtf.IXDTFExtensions{Location:America/New_York Tags:map[u-ca:gregorian] Critical:map[u-ca:true]}
+    // => &ixdtf.IXDTFExtensions{Location:America/New_York CriticalLocation:false Tags:map[u-ca:gregorian] Critical:map[u-ca:true]}
 
     // Format a time with same extensions
     now := time.Now()
@@ -181,13 +181,18 @@ The second argument `strict` in `Parse` / `Validate` controls how strictly the l
 | Mode | Behavior | Example |
 |------|----------|---------|
 | `true` | If the zone-derived offset for that instant differs from the RFC 3339 numeric offset, an **error (ErrTimezoneOffsetMismatch)** is returned. | `2025-01-01T12:00:00+09:00[America/New_York]` → New York at that instant is `-05:00`, so mismatch → error |
-| `false` | Mismatches do NOT produce an error. The original timestamp (its instant + numeric offset) is kept; the location is only applied if offsets match. | Same example above: no error; the provided time value is kept as-is (location not applied) |
+| `false` | Mismatches do NOT produce an error unless the annotation is critical (see below). The original timestamp (its instant + numeric offset) is kept; the location is only applied if offsets match. | Same example above: no error; the provided time value is kept as-is (location not applied) |
 
 Notes:
 
-- An invalid or unresolvable time zone name always yields an error (regardless of mode).
-- Time zones with `Etc/GMT±X` naming are skipped for consistency checking (POSIX inverted offset semantics would cause false positives).
-- `Validate` follows the same policy: with `strict=false` an offset mismatch is considered acceptable.
+- A time-zone annotation may carry the RFC 9557 critical flag, e.g. `[!Europe/London]`.
+  A critical zone must be processable and consistent (RFC 9557 Sections 3.3/3.4): an
+  unknown name or an offset mismatch is an error even with `strict=false`. The flag is
+  exposed as `IXDTFExtensions.CriticalLocation` and round-trips through `Format`.
+- An invalid or unresolvable time zone name yields an error in strict mode or when the
+  annotation is critical; otherwise it is ignored per RFC 9557.
+- `Validate` follows the same policy as `Parse`: with `strict=false` an offset mismatch
+  is acceptable unless the annotation is critical.
 - Extension tag syntax and critical tag handling are independent of `strict`, except for
   `u-ca` validation which is enforced in strict mode even for non-critical tags.
 - Recommended usage: accept loosely formed inputs with `strict=false` at system boundaries (ingest phase), then re-normalize if needed; enforce `strict=true` where data integrity or audit requirements apply.

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -57,6 +57,12 @@ var (
 type IXDTFExtensions struct {
 	Location *time.Location
 
+	// CriticalLocation reports whether the time-zone annotation carried a
+	// critical "!" flag (e.g. "[!Europe/London]"). Per RFC 9557 Section 3.3 a
+	// critical annotation MUST be processable, and per Section 3.4 an
+	// application MUST act on any inconsistency it introduces.
+	CriticalLocation bool
+
 	// Tags contains extension tags as key-value pairs.
 	// Example: map[ExtensionUnicodeCalendar]"japanese".
 	Tags map[string]string
@@ -120,23 +126,26 @@ func FormatNano(t time.Time, ext *IXDTFExtensions) (string, error) {
 
 // NewIXDTFExtensionsArgs contains the arguments for creating IXDTFExtensions.
 type NewIXDTFExtensionsArgs struct {
-	Location *time.Location
-	Tags     map[string]string
-	Critical map[string]bool
+	Location         *time.Location
+	CriticalLocation bool
+	Tags             map[string]string
+	Critical         map[string]bool
 }
 
 // NewIXDTFExtensions creates a new IXDTFExtensions with initialized maps.
 func NewIXDTFExtensions(args *NewIXDTFExtensionsArgs) *IXDTFExtensions {
 	ext := &IXDTFExtensions{
-		Location: nil,
-		Tags:     make(map[string]string),
-		Critical: make(map[string]bool),
+		Location:         nil,
+		CriticalLocation: false,
+		Tags:             make(map[string]string),
+		Critical:         make(map[string]bool),
 	}
 
 	if args != nil {
 		if args.Location != nil {
 			ext.Location = args.Location
 		}
+		ext.CriticalLocation = args.CriticalLocation
 		if args.Tags != nil {
 			ext.Tags = args.Tags
 		}
@@ -173,7 +182,9 @@ func Parse(s string, strict bool) (time.Time, *IXDTFExtensions, error) {
 	// Check timezone consistency if timezone is provided
 	if ext.Location != nil {
 		offsetUnknown := hasUnknownLocalOffset(rfc3339Portion)
-		result, checkErr := checkTimezoneConsistency(t, ext.Location, strict, offsetUnknown)
+		// A critical time zone must be acted upon, so an inconsistency is an
+		// error even in non-strict mode (RFC 9557 Section 3.4).
+		result, checkErr := checkTimezoneConsistency(t, ext.Location, strict || ext.CriticalLocation, offsetUnknown)
 		if checkErr != nil {
 			return time.Time{}, nil, newParseError(
 				LayoutRFC3339NanoExtended,
@@ -223,7 +234,9 @@ func Validate(s string, strict bool) error {
 	// Check timezone consistency if timezone is provided
 	if ext != nil && ext.Location != nil {
 		offsetUnknown := hasUnknownLocalOffset(rfc3339Portion)
-		_, tzErr := checkTimezoneConsistency(t, ext.Location, strict, offsetUnknown)
+		// A critical time zone must be acted upon, so an inconsistency is an
+		// error even in non-strict mode (RFC 9557 Section 3.4).
+		_, tzErr := checkTimezoneConsistency(t, ext.Location, strict || ext.CriticalLocation, offsetUnknown)
 		if tzErr != nil {
 			return newParseError(LayoutRFC3339NanoExtended, s, tzErr)
 		}
@@ -264,6 +277,9 @@ func appendSuffix(t time.Time, ext *IXDTFExtensions, format string) []byte {
 		locName := loc.String()
 		if locName != "" {
 			b = append(b, '[')
+			if ext.CriticalLocation {
+				b = append(b, '!')
+			}
 			b = append(b, locName...)
 			b = append(b, ']')
 		}
@@ -554,16 +570,20 @@ func parseSuffixElement(content string, ext *IXDTFExtensions, strict bool) error
 	}
 
 	// Timezone name handling.
-	if critical {
-		return ErrInvalidTimezone // Timezone cannot be critical
-	}
+	//
+	// RFC 9557 Section 4.1 permits a critical flag ("!") on a time-zone
+	// annotation, e.g. "[!Europe/London]" (Figure 1/Figure 2). A critical
+	// annotation MUST be processable (Section 3.3), so an unknown or invalid
+	// name is rejected even in non-strict mode.
 	tzContent := content[startIdx:]
 	if tzContent == "" {
 		return nil
 	}
+	tzStrict := strict || critical
 
 	if loc, ok := tryLoadTimezone(tzContent); ok {
 		ext.Location = loc
+		ext.CriticalLocation = critical
 		return nil
 	}
 
@@ -575,14 +595,15 @@ func parseSuffixElement(content string, ext *IXDTFExtensions, strict bool) error
 			// Convert "+09:00" to "+0900" format for timezone name
 			zoneName := formatOffsetName(tzContent)
 			ext.Location = time.FixedZone(zoneName, offset)
+			ext.CriticalLocation = critical
 			return nil
 		}
 	}
 
 	// Try to validate timezone existence
-	if err := abnf.AbnfTimezone.ValidateTimezone(tzContent, strict); err != nil {
+	if err := abnf.AbnfTimezone.ValidateTimezone(tzContent, tzStrict); err != nil {
 		// In non-strict mode, ignore unknown timezone names per RFC 9557
-		if !strict {
+		if !tzStrict {
 			return nil
 		}
 		return ErrInvalidTimezone
@@ -591,7 +612,7 @@ func parseSuffixElement(content string, ext *IXDTFExtensions, strict bool) error
 	// Additional check: try to load the timezone to see if it actually exists
 	if _, err := time.LoadLocation(tzContent); err != nil {
 		// In non-strict mode, ignore unknown timezone names per RFC 9557
-		if !strict {
+		if !tzStrict {
 			return nil
 		}
 		return ErrInvalidTimezone
@@ -599,6 +620,7 @@ func parseSuffixElement(content string, ext *IXDTFExtensions, strict bool) error
 
 	// Timezone exists - set the location
 	ext.Location = time.FixedZone(tzContent, 0)
+	ext.CriticalLocation = critical
 	return nil
 }
 

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -685,6 +685,13 @@ func validateExtensionsStrict(ext *IXDTFExtensions, strict bool) error {
 		return err
 	}
 
+	// A critical time-zone flag without a zone cannot be honored; emitting
+	// output that silently drops the "!" would violate RFC 9557 Section 3.3.
+	// This mirrors validateCriticalTags for the Critical map.
+	if ext.CriticalLocation && ext.Location == nil {
+		return ErrCriticalExtension
+	}
+
 	if err := validateTagKeys(ext.Tags); err != nil {
 		return err
 	}

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -340,23 +340,23 @@ func checkTimezoneConsistency(
 		return result, nil
 	}
 	loc := ensureRealLocation(location)
-	if loc == nil {
-		if isOffsetLocationName(location.String()) {
-			// A numeric-offset annotation (e.g. "[+09:00]") produced this
-			// FixedZone; its offset is authoritative, so use it directly.
-			loc = location
-		} else {
-			loaded, err := loadLocationCached(location.String())
-			if err != nil {
-				// In non-strict mode, ignore unknown timezone errors per RFC 9557
-				if !strict {
-					result.IsConsistent = true // Can't check consistency for unknown timezone
-					return result, nil
-				}
-				return result, err
+	switch {
+	case loc != nil:
+	case isOffsetLocationName(location.String()):
+		// A numeric-offset annotation (e.g. "[+09:00]") produced this
+		// FixedZone; its offset is authoritative, so use it directly.
+		loc = location
+	default:
+		loaded, err := loadLocationCached(location.String())
+		if err != nil {
+			// In non-strict mode, ignore unknown timezone errors per RFC 9557
+			if !strict {
+				result.IsConsistent = true // Can't check consistency for unknown timezone
+				return result, nil
 			}
-			loc = loaded
+			return result, err
 		}
+		loc = loaded
 	}
 	result.Location = loc
 

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -106,6 +106,8 @@ type TimezoneConsistencyResult struct {
 }
 
 // Format formats a time with IXDTF extensions using RFC 3339 format.
+// The time-zone annotation is emitted with a leading "!" when
+// ext.CriticalLocation is set.
 func Format(t time.Time, ext *IXDTFExtensions) (string, error) {
 	// Validate extensions (including critical tag processing).
 	if err := validateExtensions(ext); err != nil {
@@ -117,6 +119,8 @@ func Format(t time.Time, ext *IXDTFExtensions) (string, error) {
 }
 
 // FormatNano formats a time with IXDTF extensions using RFC 3339 format with nanoseconds.
+// The time-zone annotation is emitted with a leading "!" when
+// ext.CriticalLocation is set.
 func FormatNano(t time.Time, ext *IXDTFExtensions) (string, error) {
 	// Validate extensions (including critical tag processing).
 	if err := validateExtensions(ext); err != nil {
@@ -129,7 +133,9 @@ func FormatNano(t time.Time, ext *IXDTFExtensions) (string, error) {
 
 // NewIXDTFExtensionsArgs contains the arguments for creating IXDTFExtensions.
 type NewIXDTFExtensionsArgs struct {
-	Location         *time.Location
+	Location *time.Location
+	// CriticalLocation marks the time-zone annotation as critical ("!");
+	// see IXDTFExtensions.CriticalLocation.
 	CriticalLocation bool
 	Tags             map[string]string
 	Critical         map[string]bool
@@ -243,8 +249,9 @@ func Validate(s string, strict bool) error {
 		if tzErr != nil {
 			return newParseError(LayoutRFC3339NanoExtended, s, tzErr)
 		}
-		// Note: Inconsistencies are not treated as validation errors per RFC 9557
-		// but invalid timezone names will cause errors
+		// Non-critical inconsistencies are not validation errors in
+		// non-strict mode; strict mode or a critical zone turns them into
+		// errors above.
 	}
 
 	// Optional: check if the complete string matches the ABNF pattern.
@@ -385,8 +392,9 @@ func checkTimezoneConsistency(
 		return nil, ErrTimezoneOffsetMismatch
 	}
 
-	// Per RFC 9557, inconsistencies should be detectable but not cause failures.
-	// This allows applications to handle inconsistencies as needed.
+	// In non-strict mode (callers escalate critical zones to strict per
+	// RFC 9557 Section 3.4), inconsistencies are recorded in the result but
+	// do not cause failures.
 	return result, nil
 }
 
@@ -575,7 +583,8 @@ func parseSuffixElement(content string, ext *IXDTFExtensions, strict bool) error
 	// Timezone name handling.
 	//
 	// RFC 9557 Section 4.1 permits a critical flag ("!") on a time-zone
-	// annotation, e.g. "[!Europe/London]" (Figure 1/Figure 2). A critical
+	// annotation, e.g. "[!Europe/London]" (Figures 1 and 2 in Section 3.4).
+	// A critical
 	// annotation MUST be processable (Section 3.3), so an unknown or invalid
 	// name is rejected even in non-strict mode.
 	//

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -98,7 +98,10 @@ type TimezoneConsistencyResult struct {
 	ExpectedOffset int
 	// Timezone is the timezone identifier that was checked.
 	Timezone string
-	// Skipped indicates if the consistency check was skipped (e.g., for Etc/GMT).
+	// Skipped indicates if the consistency check was skipped.
+	//
+	// Deprecated: no checks are skipped anymore; the field is retained for
+	// API compatibility and is always false.
 	Skipped bool
 }
 
@@ -313,7 +316,7 @@ func appendSuffix(t time.Time, ext *IXDTFExtensions, format string) []byte {
 }
 
 // checkTimezoneConsistency checks if the timezone offset matches the IANA timezone.
-// If strict is true, returns an error when offsets don't match (except for Etc/GMT patterns).
+// If strict is true, returns an error when offsets don't match.
 // Returns consistency information and an error for timezone loading failures or strict mode mismatches.
 func checkTimezoneConsistency(
 	timestamp time.Time,
@@ -372,15 +375,9 @@ func checkTimezoneConsistency(
 	result.OriginalOffset = originalOffset
 	result.ExpectedOffset = expectedOffset
 
-	// For certain timezone patterns (like Etc/GMT-X), skip consistency checks.
-	// These have POSIX-inverted offset semantics that cause false inconsistency reports.
-	if strings.HasPrefix(loc.String(), "Etc/GMT") {
-		result.Skipped = true
-		result.IsConsistent = true // Assume consistent for Etc/GMT patterns
-		return result, nil
-	}
-
 	// Check if offsets match (allowing for some flexibility with DST transitions).
+	// Etc/GMT zones need no special casing: their POSIX-inverted sign only
+	// affects the name, and Go resolves the actual offset correctly.
 	result.IsConsistent = (originalOffset == expectedOffset)
 
 	// In strict mode, return an error for inconsistencies

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -331,16 +331,22 @@ func checkTimezoneConsistency(
 	}
 	loc := ensureRealLocation(location)
 	if loc == nil {
-		loaded, err := loadLocationCached(location.String())
-		if err != nil {
-			// In non-strict mode, ignore unknown timezone errors per RFC 9557
-			if !strict {
-				result.IsConsistent = true // Can't check consistency for unknown timezone
-				return result, nil
+		if isOffsetLocationName(location.String()) {
+			// A numeric-offset annotation (e.g. "[+09:00]") produced this
+			// FixedZone; its offset is authoritative, so use it directly.
+			loc = location
+		} else {
+			loaded, err := loadLocationCached(location.String())
+			if err != nil {
+				// In non-strict mode, ignore unknown timezone errors per RFC 9557
+				if !strict {
+					result.IsConsistent = true // Can't check consistency for unknown timezone
+					return result, nil
+				}
+				return result, err
 			}
-			return result, err
+			loc = loaded
 		}
-		loc = loaded
 	}
 	result.Location = loc
 
@@ -704,6 +710,11 @@ func validateLocationStrict(location *time.Location, strict bool) error {
 		return nil
 	}
 	if ensureRealLocation(location) == nil {
+		// An offset-derived FixedZone (e.g. from "[+09:00]") is valid as-is
+		// and never resolvable via the timezone database.
+		if isOffsetLocationName(location.String()) {
+			return nil
+		}
 		if _, err := loadLocationCached(location.String()); err != nil {
 			// In non-strict mode, ignore unknown timezone errors per RFC 9557
 			if !strict {
@@ -826,6 +837,22 @@ func formatOffsetName(offset string) string {
 		return offset[:3] + offset[4:]
 	}
 	return offset
+}
+
+// isOffsetLocationName reports whether name is a numeric-offset zone name as
+// produced by formatOffsetName (e.g. "+0900", "-0330"). Such a location's
+// offset is authoritative and has no timezone-database entry, so it must not
+// be resolved via time.LoadLocation (the lookup would always fail).
+func isOffsetLocationName(name string) bool {
+	if len(name) != 5 || (name[0] != '+' && name[0] != '-') {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // ensureRealLocation returns nil if the given location appears to be a placeholder FixedZone

--- a/ixdtf.go
+++ b/ixdtf.go
@@ -575,6 +575,13 @@ func parseSuffixElement(content string, ext *IXDTFExtensions, strict bool) error
 	// annotation, e.g. "[!Europe/London]" (Figure 1/Figure 2). A critical
 	// annotation MUST be processable (Section 3.3), so an unknown or invalid
 	// name is rejected even in non-strict mode.
+	//
+	// The grammar allows at most one time-zone annotation; a second one would
+	// overwrite the zone and its critical flag, hiding a mandatory Section 3.4
+	// inconsistency error.
+	if ext.Location != nil {
+		return ErrInvalidSuffix
+	}
 	tzContent := content[startIdx:]
 	if tzContent == "" {
 		return nil

--- a/ixdtf_internal_test.go
+++ b/ixdtf_internal_test.go
@@ -157,6 +157,65 @@ func TestParseNumericOffset(t *testing.T) {
 			t.Fatalf("expected parseNumericOffset to reject missing colon")
 		}
 	})
+
+	t.Run("invalid hours", func(t *testing.T) {
+		t.Parallel()
+		if _, err := parseNumericOffset("+24:00"); err == nil {
+			t.Fatalf("expected parseNumericOffset to reject invalid hours")
+		}
+	})
+}
+
+func TestIsOffsetLocationName(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"+0900":  true,
+		"-0330":  true,
+		"":       false,
+		"+090":   false,
+		"+09:00": false,
+		"09000":  false,
+		"+09a0":  false,
+	}
+	for name, want := range cases {
+		if got := isOffsetLocationName(name); got != want {
+			t.Errorf("isOffsetLocationName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// TestCheckTimezoneConsistencyUnloadableZone covers the resolution fallback
+// for a location that is neither cached, offset-derived, nor loadable from
+// the timezone database.
+func TestCheckTimezoneConsistencyUnloadableZone(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	unknown := time.FixedZone("Not/AZone", 0)
+
+	t.Run("non-strict treats unloadable zone as consistent", func(t *testing.T) {
+		t.Parallel()
+		result, err := checkTimezoneConsistency(ts, unknown, false, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsConsistent {
+			t.Errorf("expected IsConsistent for unloadable zone in non-strict mode")
+		}
+	})
+
+	t.Run("strict errors on unloadable zone", func(t *testing.T) {
+		t.Parallel()
+		if _, err := checkTimezoneConsistency(ts, unknown, true, false); err == nil {
+			t.Fatalf("expected error for unloadable zone in strict mode")
+		}
+	})
+}
+
+func TestEnsureRealLocationNil(t *testing.T) {
+	t.Parallel()
+	if got := ensureRealLocation(nil); got != nil {
+		t.Fatalf("ensureRealLocation(nil) = %v, want nil", got)
+	}
 }
 
 func TestParseSuffix(t *testing.T) {

--- a/ixdtf_internal_test.go
+++ b/ixdtf_internal_test.go
@@ -161,11 +161,28 @@ func TestParseNumericOffset(t *testing.T) {
 
 func TestParseSuffix(t *testing.T) {
 	t.Parallel()
-	t.Run("critical timezone", func(t *testing.T) {
+	t.Run("critical timezone is accepted", func(t *testing.T) {
 		t.Parallel()
+		// RFC 9557 Section 4.1 permits a "!" flag on a time-zone annotation.
 		ext := NewIXDTFExtensions(nil)
-		if err := parseSuffixElement("!Asia/Tokyo", ext, false); !errors.Is(err, ErrInvalidTimezone) {
-			t.Fatalf("expected ErrInvalidTimezone for critical timezone, got %v", err)
+		if err := parseSuffixElement("!Asia/Tokyo", ext, false); err != nil {
+			t.Fatalf("expected critical timezone to be accepted, got %v", err)
+		}
+		if ext.Location == nil || ext.Location.String() != "Asia/Tokyo" {
+			t.Fatalf("expected Asia/Tokyo location, got %+v", ext.Location)
+		}
+		if !ext.CriticalLocation {
+			t.Fatalf("expected CriticalLocation to be true")
+		}
+	})
+
+	t.Run("critical unknown timezone is rejected in non-strict mode", func(t *testing.T) {
+		t.Parallel()
+		// A critical annotation MUST be processable (Section 3.3), so an
+		// unknown name is an error even in non-strict mode.
+		ext := NewIXDTFExtensions(nil)
+		if err := parseSuffixElement("!Foo/Bar", ext, false); !errors.Is(err, ErrInvalidTimezone) {
+			t.Fatalf("expected ErrInvalidTimezone for critical unknown timezone, got %v", err)
 		}
 	})
 

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -1180,12 +1180,7 @@ func TestParseCriticalTimezone(t *testing.T) {
 		// July; the critical flag forces the error even in non-strict mode.
 		const input = "2022-07-08T00:14:07+00:00[!Europe/London]"
 		_, _, err := ixdtf.Parse(input, false)
-		if err == nil {
-			t.Fatalf("Parse(%q, false) expected inconsistency error, got nil", input)
-		}
-		if !strings.Contains(err.Error(), "timezone offset does not match") {
-			t.Errorf("Parse(%q, false) error = %v, want offset mismatch", input, err)
-		}
+		checkParseError(t, err, input, false, "timezone offset does not match")
 	})
 }
 

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -463,6 +463,21 @@ func TestParse(t *testing.T) {
 			),
 		},
 		{
+			// Etc/GMT+3 is UTC-03:00 (POSIX-inverted sign); a concrete +05:00
+			// conflicts with it, and the critical flag forces the error even
+			// in non-strict mode (RFC 9557 Section 3.4).
+			name:    "critical Etc/GMT zone with mismatching offset errors in non-strict",
+			input:   "2022-07-08T00:14:07+05:00[!Etc/GMT+3]",
+			strict:  false,
+			wantErr: "timezone offset does not match",
+		},
+		{
+			name:    "Etc/GMT zone with mismatching offset errors in strict mode",
+			input:   "2022-07-08T00:14:07+05:00[Etc/GMT+3]",
+			strict:  true,
+			wantErr: "timezone offset does not match",
+		},
+		{
 			name:     "timezone with Etc/GMT pattern in strict mode",
 			input:    "2025-01-01T00:00:00+05:00[Etc/GMT-5]",
 			strict:   true,

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -518,8 +518,31 @@ func TestParse(t *testing.T) {
 			wantErr: "experimental extension cannot be processed",
 		},
 		{
-			name:    "critical timezone is invalid",
-			input:   "2025-01-01T00:00:00Z[!Asia/Tokyo]",
+			// RFC 9557 Section 4.1 permits a critical "!" flag on a time zone;
+			// combined with Z (unknown offset) it is consistent (Figure 2).
+			name:     "critical timezone with Z is accepted",
+			input:    "2025-01-01T00:00:00Z[!Asia/Tokyo]",
+			strict:   false,
+			wantTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantExt: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{
+				Location:         time.FixedZone("Asia/Tokyo", 9*3600),
+				CriticalLocation: true,
+			}),
+		},
+		{
+			// Critical + concrete offset that conflicts with the zone: an
+			// application MUST act on the inconsistency even in non-strict
+			// mode (RFC 9557 Section 3.4).
+			name:    "critical timezone inconsistent offset errors in non-strict",
+			input:   "2022-07-08T00:14:07+00:00[!Europe/London]",
+			strict:  false,
+			wantErr: "timezone offset does not match",
+		},
+		{
+			// A critical annotation MUST be processable (Section 3.3), so an
+			// unknown name errors even in non-strict mode.
+			name:    "critical unknown timezone errors in non-strict",
+			input:   "2025-01-01T00:00:00Z[!Foo/Bar]",
 			strict:  false,
 			wantErr: "invalid timezone",
 		},
@@ -924,6 +947,10 @@ func extensionsEqual(a, b *ixdtf.IXDTFExtensions) bool {
 		}
 	}
 
+	if a.CriticalLocation != b.CriticalLocation {
+		return false
+	}
+
 	if len(a.Tags) != len(b.Tags) {
 		return false
 	}
@@ -1011,6 +1038,56 @@ func TestParseUnknownLocalOffsetAppliesTimezone(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseCriticalTimezone verifies RFC 9557 handling of a critical "!" flag
+// on a time-zone annotation (Section 4.1 grammar; Section 3.3/3.4 semantics).
+// See the follow-up to https://github.com/8beeeaaat/ixdtf/issues/22.
+func TestParseCriticalTimezone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Z with critical zone is consistent in both modes", func(t *testing.T) {
+		t.Parallel()
+		const input = "2022-07-08T00:14:07Z[!Europe/London]" // Figure 2: no inconsistency
+		for _, strict := range []bool{false, true} {
+			got, ext, err := ixdtf.Parse(input, strict)
+			if err != nil {
+				t.Fatalf("Parse(%q, %v) unexpected error: %v", input, strict, err)
+			}
+			if !ext.CriticalLocation {
+				t.Errorf("Parse(%q, %v) expected CriticalLocation to be true", input, strict)
+			}
+			if _, off := got.Zone(); off != 1*3600 { // London is BST (+01:00) in July
+				t.Errorf("Parse(%q, %v) offset = %d, want %d", input, strict, off, 1*3600)
+			}
+		}
+	})
+
+	t.Run("critical zone round-trips with the ! flag", func(t *testing.T) {
+		t.Parallel()
+		const input = "2025-01-01T00:00:00+09:00[!Asia/Tokyo]"
+		got, ext, err := ixdtf.Parse(input, true)
+		if err != nil {
+			t.Fatalf("Parse(%q) unexpected error: %v", input, err)
+		}
+		formatted, err := ixdtf.Format(got, ext)
+		if err != nil {
+			t.Fatalf("Format unexpected error: %v", err)
+		}
+		if formatted != input {
+			t.Errorf("round trip failed: got %q, want %q", formatted, input)
+		}
+	})
+
+	t.Run("critical inconsistency errors in non-strict mode", func(t *testing.T) {
+		t.Parallel()
+		// +00:00 asserts a zero offset that conflicts with London's +01:00 in
+		// July; the critical flag forces the error even in non-strict mode.
+		const input = "2022-07-08T00:14:07+00:00[!Europe/London]"
+		if _, _, err := ixdtf.Parse(input, false); err == nil {
+			t.Fatalf("Parse(%q, false) expected inconsistency error, got nil", input)
+		}
+	})
 }
 
 // TestParseNumericZeroOffsetStillInconsistent verifies the contrast with Z: a

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -564,6 +564,18 @@ func TestParse(t *testing.T) {
 			wantErr: "timezone offset does not match",
 		},
 		{
+			// "-00:00" is the other unknown-local-offset form (RFC 9557
+			// Section 2.2), so a critical zone pairs with it consistently.
+			name:     "critical timezone with -00:00 is accepted",
+			input:    "2022-07-08T00:14:07-00:00[!Europe/London]",
+			strict:   false,
+			wantTime: time.Date(2022, 7, 8, 0, 14, 7, 0, time.UTC),
+			wantExt: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{
+				Location:         time.FixedZone("Europe/London", 1*3600),
+				CriticalLocation: true,
+			}),
+		},
+		{
 			// A critical annotation MUST be processable (Section 3.3), so an
 			// unknown name errors even in non-strict mode.
 			name:    "critical unknown timezone errors in non-strict",
@@ -747,6 +759,18 @@ func TestValidate(t *testing.T) {
 		{
 			name:   "valid with critical tag",
 			input:  "2025-03-04T05:06:07Z[!u-ca=gregory]",
+			strict: false,
+		},
+		{
+			// Validate must accept a critical zone exactly like Parse does
+			// (RFC 9557 Section 3.4, Figure 2: Z carries no local offset).
+			name:   "valid with critical timezone",
+			input:  "2022-07-08T00:14:07Z[!Europe/London]",
+			strict: false,
+		},
+		{
+			name:   "valid with critical numeric offset",
+			input:  "2025-01-01T00:00:00+09:00[!+09:00]",
 			strict: false,
 		},
 		{
@@ -1155,8 +1179,12 @@ func TestParseCriticalTimezone(t *testing.T) {
 		// +00:00 asserts a zero offset that conflicts with London's +01:00 in
 		// July; the critical flag forces the error even in non-strict mode.
 		const input = "2022-07-08T00:14:07+00:00[!Europe/London]"
-		if _, _, err := ixdtf.Parse(input, false); err == nil {
+		_, _, err := ixdtf.Parse(input, false)
+		if err == nil {
 			t.Fatalf("Parse(%q, false) expected inconsistency error, got nil", input)
+		}
+		if !strings.Contains(err.Error(), "timezone offset does not match") {
+			t.Errorf("Parse(%q, false) error = %v, want offset mismatch", input, err)
 		}
 	})
 }

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -573,6 +573,37 @@ func TestParse(t *testing.T) {
 			}),
 		},
 		{
+			// RFC 9557 Section 4.1 permits a critical numeric-offset
+			// annotation; a matching offset is fully processable
+			// (Section 3.3) and consistent (Section 3.4).
+			name:     "critical matching numeric offset is accepted",
+			input:    "2025-01-01T00:00:00+09:00[!+09:00]",
+			strict:   false,
+			wantTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.FixedZone("+0900", 9*3600)),
+			wantExt: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{
+				Location:         time.FixedZone("+0900", 9*3600),
+				CriticalLocation: true,
+			}),
+		},
+		{
+			name:    "critical mismatching numeric offset errors in non-strict",
+			input:   "2025-01-01T00:00:00+09:00[!+05:30]",
+			strict:  false,
+			wantErr: "timezone offset does not match",
+		},
+		{
+			// An offset-derived FixedZone must not be resolved via the
+			// timezone database, so a matching offset annotation is valid in
+			// strict mode too.
+			name:     "matching numeric offset is accepted in strict mode",
+			input:    "2025-01-01T00:00:00+09:00[+09:00]",
+			strict:   true,
+			wantTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.FixedZone("+0900", 9*3600)),
+			wantExt: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{
+				Location: time.FixedZone("+0900", 9*3600),
+			}),
+		},
+		{
 			name:     "invalid numeric offset ignored in non-strict mode",
 			input:    "2025-01-01T00:00:00Z[+24:00]",
 			strict:   false,

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -547,6 +547,21 @@ func TestParse(t *testing.T) {
 			wantErr: "invalid timezone",
 		},
 		{
+			// The grammar allows at most one time-zone annotation (RFC 9557
+			// Section 4.1); a second one would overwrite the zone and its
+			// critical flag, hiding a mandatory Section 3.4 inconsistency error.
+			name:    "second timezone annotation rejected in non-strict",
+			input:   "2022-07-08T00:14:07+00:00[!Europe/London][Asia/Tokyo]",
+			strict:  false,
+			wantErr: "invalid IXDTF suffix format",
+		},
+		{
+			name:    "second timezone annotation rejected in strict mode",
+			input:   "2025-01-01T00:00:00Z[Asia/Tokyo][Europe/Paris]",
+			strict:  true,
+			wantErr: "invalid IXDTF suffix format",
+		},
+		{
 			name:     "timezone numeric offset suffix",
 			input:    "2025-01-01T00:00:00Z[+09:00]",
 			strict:   false,

--- a/ixdtf_test.go
+++ b/ixdtf_test.go
@@ -42,6 +42,16 @@ func TestFormat(t *testing.T) {
 			want: "2025-01-01T00:00:00Z[Asia/Tokyo]",
 		},
 		{
+			// A critical time-zone flag without a zone cannot be honored;
+			// silently dropping the "!" would violate RFC 9557 Section 3.3.
+			name: "critical location flag without location errors",
+			tm:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ext: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{
+				CriticalLocation: true,
+			}),
+			wantErr: ixdtf.ErrCriticalExtension,
+		},
+		{
 			name: "tags sorting and critical",
 			tm:   time.Date(2025, 3, 4, 5, 6, 7, 0, time.UTC),
 			ext: ixdtf.NewIXDTFExtensions(&ixdtf.NewIXDTFExtensionsArgs{

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -21,6 +21,18 @@ func TestE2E_RoundTrip(t *testing.T) {
 			overrideWithNyExtHasErrorInStrictMode: false,
 		},
 		{
+			// An accepted critical zone survives Parse -> Format with its
+			// "!" flag (Z is an unknown local offset, so no inconsistency).
+			name:                                     "critical time zone with Z",
+			input:                                    "2025-01-02T03:04:05Z[!America/New_York]",
+			inputHasErrorInNonStrictMode:             false,
+			inputHasErrorInStrictMode:                false,
+			inputFormatted:                           "2025-01-01T22:04:05-05:00[!America/New_York]",
+			overrideWithNyExt:                        "2025-01-01T22:04:05-05:00[America/New_York]",
+			overrideWithNyExtHasErrorInNonStrictMode: false,
+			overrideWithNyExtHasErrorInStrictMode:    false,
+		},
+		{
 			// A critical time zone must be processable (RFC 9557 Section 3.3);
 			// an unknown name errors in both modes.
 			name:                         "critical unknown time zone tag",

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -21,8 +21,10 @@ func TestE2E_RoundTrip(t *testing.T) {
 			overrideWithNyExtHasErrorInStrictMode: false,
 		},
 		{
-			name:                         "basic UTC time with invalid critical time zone tag",
-			input:                        "2025-01-02T03:04:05Z[!America/New_York]",
+			// A critical time zone must be processable (RFC 9557 Section 3.3);
+			// an unknown name errors in both modes.
+			name:                         "critical unknown time zone tag",
+			input:                        "2025-01-02T03:04:05Z[!Foo/Bar]",
 			inputHasErrorInNonStrictMode: true,
 			inputHasErrorInStrictMode:    true,
 		},


### PR DESCRIPTION
## Summary

Follow-up to #22. The parser rejected any time-zone annotation carrying a critical `!` flag (e.g. `[!Europe/London]`) with `invalid timezone name`, but **RFC 9557 §4.1** explicitly permits it:

```
time-zone     = "[" critical-flag (time-zone-name / time-numoffset) "]"
critical-flag = [ "!" ]
```

Figure 1/Figure 2 use `[!Europe/London]` directly. This PR accepts the flag and honors its semantics, and — following a multi-agent review of the initial commit — fixes three adjacent defects that would have silently defeated the critical-flag guarantees.

## Behavior

| Input | Before | After |
|---|---|---|
| `Z[!Europe/London]` | ❌ `invalid timezone` | ✅ zone applied, no error (Figure 2 — Z is unknown offset) |
| `+00:00[!Europe/London]` | ❌ `invalid timezone` | ❌ `timezone offset does not match` (critical inconsistency, §3.4) |
| `Z[!Foo/Bar]` | ❌ `invalid timezone` | ❌ `invalid timezone` (critical must be processable, §3.3) |
| `+00:00[!Europe/London][Asia/Tokyo]` | ✅ silently parsed | ❌ `invalid IXDTF suffix` (§4.1 allows one time-zone annotation; a second silently clobbered the zone and its critical flag) |
| `+09:00[!+09:00]` / `+09:00[+09:00]` (strict) | ❌ `unknown time zone +0900` | ✅ accepted (offset-derived FixedZone is authoritative; §4.1 permits critical offset annotations) |
| `+05:00[!Etc/GMT+3]` | ✅ silently converted to −03:00 | ❌ `timezone offset does not match` (the blanket Etc/GMT skip masked real inconsistencies; Go resolves POSIX-inverted names correctly) |
| `Format` with `CriticalLocation` but no `Location` | ✅ flag silently dropped | ❌ `ErrCriticalExtension` (mirrors `validateCriticalTags`) |

RFC semantics honored:
- **§3.3** — a critical annotation MUST be processable, so an unknown/invalid name errors **even in non-strict mode**.
- **§3.4** — an application MUST act on an inconsistency a critical time zone introduces, so a conflicting concrete offset errors **even in non-strict mode**.

## Commits

1. `fix: accept critical "!" flag on time-zone annotations per RFC 9557` — core feature: record the flag in `IXDTFExtensions.CriticalLocation`, apply effective strictness (`strict || critical`), round-trip `[!zone]` through `Format`.
2. `fix: reject a second time-zone annotation instead of overwriting the first` — a second zone annotation silently discarded the critical flag and suppressed the mandatory §3.4 error.
3. `fix: accept offset-derived time zones in consistency and strict checks` — `[+09:00]`-style annotations are stored as `FixedZone("+0900", …)`, whose name never resolves via `time.LoadLocation`; consistency/strict validation no longer round-trips them through the tz database. Fixes both the critical-mode regression and a pre-existing strict-mode bug.
4. `fix: stop skipping the consistency check for Etc/GMT zones` — the POSIX-inversion concern only affects zone *names*; Go resolves offsets correctly, so the blanket skip only hid real mismatches. `TimezoneConsistencyResult.Skipped` is retained (deprecated, always false).
5. `fix: reject CriticalLocation without Location in extension validation` — `Format` no longer silently drops a declared critical flag.
6. `test: broaden critical time-zone coverage` — Validate accept-path parity, e2e round-trip of an accepted critical zone, `-00:00[!zone]`, exact error-message assertions.
7. `docs: align comments and README with critical time-zone semantics` + `style:` lint cleanups.

## Tests

- Accept a critical zone with `Z`; round-trip the `!` flag through `Format`; error on a critical inconsistency and a critical unknown zone (unit + internal + e2e).
- Critical numeric-offset annotations: matching accepted (both modes), mismatching errors, flag survives (kills the mutation where the numeric-offset branch drops the flag).
- Duplicate time-zone annotations rejected in both modes.
- Etc/GMT: real mismatch errors in strict/critical; existing consistent `Etc/GMT-5` cases unchanged.
- `extensionsEqual` compares `CriticalLocation`.

## Quality gate

- `go test -race ./...` ✅  ·  `go vet` / `gofmt` ✅  ·  `golangci-lint run` → 0 issues ✅  ·  `go mod tidy` → no dep changes ✅

## Note

`CriticalLocation` is an additive field on the exported `IXDTFExtensions` / `NewIXDTFExtensionsArgs`, backward-compatible for keyed struct literals and the `NewIXDTFExtensions` constructor. Two behavior changes intentionally surface previously silent states: duplicate zone annotations now error, and `Etc/GMT*` zones are consistency-checked like any other zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)