### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for the critical `!` flag on time-zone annotations per RFC 9557 Section 4.1 (e.g. `[!Europe/London]`); critical zones must be processable and consistent even in non-strict mode (PR #24)
 - New `CriticalLocation` field on `IXDTFExtensions` and its constructor args, so the critical flag round-trips through `Format`/`FormatNano`
+- `ParseError` now implements `Unwrap`, so sentinel errors like `ErrTimezoneOffsetMismatch` match with `errors.Is` (PR #26)
 
 ### Changed
 
 - `Z` and `-00:00` are now treated as unknown local offset per RFC 9557 Section 2.2: pairing them with a time-zone annotation is no longer an inconsistency, and the annotation is applied to resolve local time (#22, PR #23)
 - Numeric-offset annotations like `[+09:00]` are now accepted by the consistency and strict checks instead of failing with an unknown-time-zone error
 - `TimezoneConsistencyResult.Skipped` is deprecated and always `false` now that Etc/GMT zones are no longer skipped
+- Strict mode now rejects unknown critical suffix keys other than `u-ca` with `ErrCriticalExtension`; non-strict callers can still inspect them via the `Critical` map (PR #26)
 
 ### Fixed
 
-- A second time-zone annotation (e.g. `...[Europe/London][Asia/Tokyo]`) is rejected with `ErrInvalidSuffix` instead of silently overwriting the first
+- A second time-zone annotation (e.g. `...[Europe/London][Asia/Tokyo]`) is rejected with `ErrInvalidSuffix` instead of silently overwriting the first, even when the first annotation was an ignored unknown zone (PR #24, #26)
 - Etc/GMT zones are no longer exempt from the offset consistency check, so real mismatches like `+05:00[!Etc/GMT+3]` are reported
-- `Format` returns `ErrCriticalExtension` when `CriticalLocation` is set without a `Location`, instead of silently dropping the critical flag
+- `Format` now keeps the RFC 3339 form as the zone name for offset annotations, emitting `[+09:00]` instead of the grammar-violating `[+0900]`, so Parse → Format → Parse round trips are lossless (PR #26)
+- Duplicate suffix keys are rejected with `ErrCriticalExtension` when either occurrence carries the critical flag, per RFC 9557 Section 3.3 (PR #26)
+- A time-zone annotation appearing after a suffix tag is rejected with `ErrInvalidSuffix`, enforcing the RFC 9557 `suffix = [time-zone] *suffix-tag` ordering (PR #26)
+- `Format`/`FormatNano` apply `CriticalLocation` to the timestamp's own zone when `Location` is unset, and return `ErrCriticalExtension` only when no zone is available to attach the flag to (PR #24, #26)
 
 ### Technical
 
 - Broadened test coverage for critical time-zone and unknown-local-offset paths, raising total coverage to 96.4%
+- Added RFC 9557 spec-conformance tests: Section 3.3 example strings, the Section 1.2 offset example, and Parse → Format → Parse round trips for offset annotations (PR #26)
 - Bumped GitHub Actions dependencies: actions/checkout v7, actions/cache v6, codecov/codecov-action v7 (PR #18, #19, #20, #21)
 
 ## [0.3.1] - 2026-01-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Technical
 
+- Refactored the IXDTF implementation from a monolithic file into focused modules for parsing, formatting, suffix handling, timezone resolution, validation, calendar tags, extensions, and errors, with expanded targeted tests (PR #27)
 - Broadened test coverage for critical time-zone and unknown-local-offset paths, raising total coverage to 96.4%
 - Added RFC 9557 spec-conformance tests: Section 3.3 example strings, the Section 1.2 offset example, and Parse → Format → Parse round trips for offset annotations (PR #26)
 - Bumped GitHub Actions dependencies: actions/checkout v7, actions/cache v6, codecov/codecov-action v7 (PR #18, #19, #20, #21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-07
+
+### Added
+
+- Support for the critical `!` flag on time-zone annotations per RFC 9557 Section 4.1 (e.g. `[!Europe/London]`); critical zones must be processable and consistent even in non-strict mode (PR #24)
+- New `CriticalLocation` field on `IXDTFExtensions` and its constructor args, so the critical flag round-trips through `Format`/`FormatNano`
+
+### Changed
+
+- `Z` and `-00:00` are now treated as unknown local offset per RFC 9557 Section 2.2: pairing them with a time-zone annotation is no longer an inconsistency, and the annotation is applied to resolve local time (#22, PR #23)
+- Numeric-offset annotations like `[+09:00]` are now accepted by the consistency and strict checks instead of failing with an unknown-time-zone error
+- `TimezoneConsistencyResult.Skipped` is deprecated and always `false` now that Etc/GMT zones are no longer skipped
+
+### Fixed
+
+- A second time-zone annotation (e.g. `...[Europe/London][Asia/Tokyo]`) is rejected with `ErrInvalidSuffix` instead of silently overwriting the first
+- Etc/GMT zones are no longer exempt from the offset consistency check, so real mismatches like `+05:00[!Etc/GMT+3]` are reported
+- `Format` returns `ErrCriticalExtension` when `CriticalLocation` is set without a `Location`, instead of silently dropping the critical flag
+
+### Technical
+
+- Broadened test coverage for critical time-zone and unknown-local-offset paths, raising total coverage to 96.4%
+- Bumped GitHub Actions dependencies: actions/checkout v7, actions/cache v6, codecov/codecov-action v7 (PR #18, #19, #20, #21)
+
 ## [0.3.1] - 2026-01-18
 
 ### Changed


### PR DESCRIPTION
## Summary

Prepare the v0.4.0 release: add the CHANGELOG entry covering all changes since v0.3.1, rebased on the latest `origin/main`.

## Changes since v0.3.1

- **PR #23** — treat `Z`/`-00:00` as unknown local offset per RFC 9557 Section 2.2 (#22)
- **PR #24** — accept the critical `!` flag on time-zone annotations, reject duplicate time-zone annotations, accept offset-derived zones in consistency/strict checks, stop skipping the Etc/GMT consistency check, and reject `CriticalLocation` without an attachable zone
- **PR #26** — resolve RFC 9557 compliance findings from the pre-release expert review:
  - `Format` emits offset annotations as `[+09:00]` (RFC grammar) instead of `[+0900]`, making Parse -> Format -> Parse round trips lossless
  - Duplicate suffix keys are rejected with `ErrCriticalExtension` when either occurrence is critical (Section 3.3)
  - Strict mode rejects unknown critical suffix keys other than `u-ca`
  - A second time-zone annotation is rejected even after an ignored unknown zone; a time-zone annotation after a suffix tag violates the grammar ordering and returns `ErrInvalidSuffix`
  - `Format`/`FormatNano` apply `CriticalLocation` to the timestamp's own zone when `Location` is unset
  - `ParseError` implements `Unwrap`, so sentinel errors match with `errors.Is`
- **PR #27 / `main-3`** — refactor the IXDTF implementation from a monolithic file into focused modules for parsing, formatting, suffix handling, timezone resolution, validation, calendar tags, extensions, and errors, with expanded targeted tests
- Dependabot CI bumps: actions/checkout v7, actions/cache v6, codecov-action v7

## Version rationale

Minor bump (0.3.1 -> 0.4.0): the fixes change accept/reject behavior for several inputs, and the public API gains `IXDTFExtensions.CriticalLocation` and `ParseError.Unwrap`. The PR #27 refactor preserves the public API while reorganizing implementation internals.

## Release steps after merge

```sh
git checkout main && git pull
git tag v0.4.0
git push origin v0.4.0
```

The `Release` workflow then runs tests and publishes the GitHub Release automatically.

## Verification

- `go test ./...` passes on the rebased `release/v0.4.0` branch
