### PR TITLE
docs: introduce ixdtf.8beeeaaat.com demo site in README and godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Go implementation of [RFC 9557: Internet Extended Date/Time Format (IXDTF)](ht
 
 IXDTF extends RFC 3339 by adding optional suffix elements for timezone names and additional metadata while maintaining full backward compatibility.
 
+> 🕹️ **Try it live:** an interactive demo is available at **[ixdtf.8beeeaaat.com](https://ixdtf.8beeeaaat.com/)** — see [Demo](#demo).
+
 ```go
 strictMode := false
 rfc9557 := "2025-02-03T04:05:06+09:00[Asia/Tokyo][!u-ca=gregory]"
@@ -26,6 +28,20 @@ result, _ := ixdtf.Format(parsedTime, ixdtfExtensions)
 - **Extended Format Support**: Handles timezone names and additional metadata via suffix elements
 - **Zero Dependencies**: Pure Go implementation using only the standard library
 - **Comprehensive Validation**: ABNF-based validation ensuring format compliance
+
+## Demo
+
+An interactive demo application is available at **[ixdtf.8beeeaaat.com](https://ixdtf.8beeeaaat.com/)**
+([source](https://github.com/8beeeaaat/ixdtf_demo)).
+
+It feeds the same IXDTF strings through both the browser-native
+[TC39 Temporal API](https://tc39.es/proposal-temporal/) and this library to demonstrate
+interoperability, and showcases the `Parse` / `Format` / `FormatNano` / `Validate` APIs across
+several screens: a live IXDTF clock, a Parse/Validate playground, a Temporal ↔ Go round-trip
+comparison, a timezone/calendar converter, and an RFC 9557 learning guide.
+
+> The demo relies on native `Temporal` support (Chrome 144+ / Edge 144+ / Firefox 139+) and
+> uses no polyfill, so an up-to-date browser is required.
 
 ## Installation
 

--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,10 @@
 //
 // See RFC 9557: https://datatracker.ietf.org/doc/rfc9557/
 //
+// An interactive demo is available at https://ixdtf.8beeeaaat.com/, which runs
+// IXDTF strings through both the browser-native TC39 Temporal API and this
+// library (source: https://github.com/8beeeaaat/ixdtf_demo).
+//
 // The package is organized so each file covers one RFC 9557 concern:
 //
 //   - format.go: serialization (Section 4.1) and critical output rules (Section 3.3)


### PR DESCRIPTION
## Overview


Added links and information to introduce the demo site https://ixdtf.8beeeaaat.com/ across various documentation. The demo is an SPA based on the [8beeeaaat/ixdtf_demo](https://github.com/8beeeaaat/ixdtf_demo) repository, demonstrating interoperability by processing the same IXDTF strings using both the browser-native [TC39 Temporal API](https://tc39.es/proposal-temporal/) and this library.


## Changes


- README.md: Added a live-demo link at the beginning and created a new ## Demo section. Described it as an interoperability showcase between Temporal and Go ixdtf, mentioned multiple screens for trying out Parse / Format / FormatNano / Validate, and noted that it assumes native Temporal availability (no polyfills used).
- doc.go: Added the demo URL and a reference to the source repository in the package comments (which appear on the pkg.go.dev top page).


## Verification


- gofmt -l doc.go: clean
- go build ./...: ok
- go vet ./...: ok


## References


- Demo: https://ixdtf.8beeeaaat.com/